### PR TITLE
Allow for dynamic assignment of region and service

### DIFF
--- a/src/main/java/burp/Utility.java
+++ b/src/main/java/burp/Utility.java
@@ -27,7 +27,6 @@ public class Utility {
         List<String> headers = requestInfo.getHeaders();
         if (!token.isEmpty()) {
             headers.add("X-Amz-Security-Token: " + token);
-
         }
         List<String> newHeaders = new ArrayList<>(headers);
         headers.remove(0);
@@ -36,7 +35,6 @@ public class Utility {
 
         String authHeader = "";
         String amzDate = "";
-        String toSign = "";
 
         for (String header : headers) {
             if (header.toLowerCase().startsWith("authorization:")){
@@ -44,6 +42,20 @@ public class Utility {
             }
             if (header.toLowerCase().startsWith("x-amz-date:")){
                 amzDate = header;
+            }
+            if (header.toLowerCase().startsWith("credential") && !header.contains(service)) {
+                try {
+                    headers.remove("X-Amz-Security-Token: " + token);
+                } catch (Exception e) {
+                    continue;
+                }
+                byte[] request = messageInfo.getRequest();
+                String body = "";
+                if (!requestInfo.getMethod().equals("GET")){
+                    int bodyOffset = requestInfo.getBodyOffset();
+                    body = new String(request, bodyOffset, request.length - bodyOffset, "UTF-8").trim();
+                }
+                return helpers.buildHttpMessage(headers, body.getBytes());
             }
             String[] headerPair = header.split(":",2);
             headerMap.put(headerPair[0].trim(),headerPair[1].trim());


### PR DESCRIPTION
- Added a checkbox to dynamically assign the region and service to be
signed
- If checkbox is unchecked, AWSSigner will not sign requests that do not
match the region and service specified in the profile
- If it is checked, AWSSigner will load the service and region from the
request it receives, meaning it will sign every request