### PR TITLE
2.0.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 group "com.netspi.awssigner"
-version "2.0.0"
+version "2.0.1"
 
 apply plugin: "java"
 

--- a/src/main/java/com/netspi/awssigner/controller/AWSSignerController.java
+++ b/src/main/java/com/netspi/awssigner/controller/AWSSignerController.java
@@ -294,6 +294,7 @@ public class AWSSignerController {
                     Profile newProfile = newProfileOptional.get();
                     if (profile.getName().equals(newProfile.getName())) {
                         //Showing the same profile. we can update UI fields. 
+                        view.profileStatusTextLabel.putClientProperty("html.disable", null);
                         view.profileStatusTextLabel.setText("<html><font color='darkgreen'>Success</font></html>");
                         if (profile instanceof CommandProfile) {
                             view.commandExtractedAccessKeyTextField.setText(creds.getAccessKey());
@@ -781,6 +782,7 @@ public class AWSSignerController {
 
         //The first profile is special since it represents NOT having a default profile
         JRadioButtonMenuItem noDefaultProfileItem = new JRadioButtonMenuItem("<html><i>No Profile</i></html>", model.alwaysSignWithProfile == null);
+        noDefaultProfileItem.putClientProperty("html.disable", null);
         noDefaultProfileItem.addActionListener((event) -> {
             logDebug("Always sign with profile unset via context menu");
             model.alwaysSignWithProfile = null;

--- a/src/main/java/com/netspi/awssigner/view/BurpTabPanel.form
+++ b/src/main/java/com/netspi/awssigner/view/BurpTabPanel.form
@@ -167,6 +167,9 @@
             </Property>
             <Property name="text" type="java.lang.String" value="&lt;html&gt;Change extension behavior. Set &lt;i&gt;Always Sign With&lt;/i&gt; to force signing of all requests with the specified profile credentials."/>
           </Properties>
+          <AuxValues>
+            <AuxValue name="JavaCodeGenerator_InitCodePost" type="java.lang.String" value="globalSettingsDescriptionLabel.putClientProperty(&quot;html.disable&quot;, null);"/>
+          </AuxValues>
         </Component>
         <Component class="javax.swing.JCheckBox" name="signingEnabledCheckbox">
           <Properties>
@@ -1146,6 +1149,9 @@
                                 <Property name="text" type="java.lang.String" value="&lt;html&gt; The session policy is an &lt;b&gt;optional&lt;/b&gt; IAM policy which further &lt;b&gt;restricts&lt;/b&gt; the permissions of the assumed role. The permissions for a session are the intersection of the identity-based policies for the IAM role used to create the session and the session policy."/>
                                 <Property name="verticalAlignment" type="int" value="1"/>
                               </Properties>
+                              <AuxValues>
+                                <AuxValue name="JavaCodeGenerator_InitCodePost" type="java.lang.String" value="assumeRoleSessionPolicyDescriptionLabel.putClientProperty(&quot;html.disable&quot;, null);"/>
+                              </AuxValues>
                             </Component>
                             <Container class="javax.swing.JScrollPane" name="assumeRoleSessionPolicyScrollPane">
                               <AuxValues>
@@ -1310,6 +1316,9 @@
                               <Dimension value="[500, 14]"/>
                             </Property>
                           </Properties>
+                          <AuxValues>
+                            <AuxValue name="JavaCodeGenerator_InitCodePost" type="java.lang.String" value="commandConfigurationDescriptionLabel.putClientProperty(&quot;html.disable&quot;, null);"/>
+                          </AuxValues>
                         </Component>
                         <Component class="javax.swing.JLabel" name="commandCommandLabel">
                           <Properties>
@@ -1372,6 +1381,9 @@
                               <Dimension value="[500, 14]"/>
                             </Property>
                           </Properties>
+                          <AuxValues>
+                            <AuxValue name="JavaCodeGenerator_InitCodePost" type="java.lang.String" value="commandExtractedSectionDescriptionLabel.putClientProperty(&quot;html.disable&quot;, null);"/>
+                          </AuxValues>
                         </Component>
                         <Component class="javax.swing.JLabel" name="commandExtractedAccessKeyLabel">
                           <Properties>

--- a/src/main/java/com/netspi/awssigner/view/BurpTabPanel.java
+++ b/src/main/java/com/netspi/awssigner/view/BurpTabPanel.java
@@ -119,6 +119,7 @@ public class BurpTabPanel extends javax.swing.JPanel {
 
         globalSettingsDescriptionLabel.setFont(globalSettingsDescriptionLabel.getFont());
         globalSettingsDescriptionLabel.setText("<html>Change extension behavior. Set <i>Always Sign With</i> to force signing of all requests with the specified profile credentials.");
+        globalSettingsDescriptionLabel.putClientProperty("html.disable", null);
 
         signingEnabledCheckbox.setFont(signingEnabledCheckbox.getFont());
         signingEnabledCheckbox.setSelected(true);
@@ -405,6 +406,7 @@ public class BurpTabPanel extends javax.swing.JPanel {
         assumeRoleSessionPolicyDescriptionLabel.setFont(assumeRoleSessionPolicyDescriptionLabel.getFont());
         assumeRoleSessionPolicyDescriptionLabel.setText("<html> The session policy is an <b>optional</b> IAM policy which further <b>restricts</b> the permissions of the assumed role. The permissions for a session are the intersection of the identity-based policies for the IAM role used to create the session and the session policy.");
         assumeRoleSessionPolicyDescriptionLabel.setVerticalAlignment(javax.swing.SwingConstants.TOP);
+        assumeRoleSessionPolicyDescriptionLabel.putClientProperty("html.disable", null);
 
         assumeRoleSessionPolicyTextArea.setColumns(20);
         assumeRoleSessionPolicyTextArea.setRows(5);
@@ -511,6 +513,7 @@ public class BurpTabPanel extends javax.swing.JPanel {
         commandConfigurationDescriptionLabel.setText("<html>The provided command will be executed to obtain credentials for request signing, as required. If a <i>Duration</i> value is provided, the credentials will considered valid for that duration. If a <i>Duration</i> value is not provided, the credentials will be cached for 60 minutes. If the <i>Duration</i> value is value is 0, then the command will be executed before each request. The extension will attempt to identify and extract the first valid Access Key, Secret Key and Session Token in the command stdout output.");
         commandConfigurationDescriptionLabel.setVerticalAlignment(javax.swing.SwingConstants.TOP);
         commandConfigurationDescriptionLabel.setPreferredSize(new java.awt.Dimension(500, 14));
+        commandConfigurationDescriptionLabel.putClientProperty("html.disable", null);
 
         commandCommandLabel.setFont(commandCommandLabel.getFont().deriveFont(commandCommandLabel.getFont().getStyle() | java.awt.Font.BOLD, commandCommandLabel.getFont().getSize()+1));
         commandCommandLabel.setText("Command:");
@@ -531,6 +534,7 @@ public class BurpTabPanel extends javax.swing.JPanel {
         commandExtractedSectionDescriptionLabel.setText("<html>Click the <i>Test Profile Credentials</i> button above to test the provided command, credential extraction and the credentials' validity. The most recently extracted credentials are shown below.");
         commandExtractedSectionDescriptionLabel.setVerticalAlignment(javax.swing.SwingConstants.TOP);
         commandExtractedSectionDescriptionLabel.setPreferredSize(new java.awt.Dimension(500, 14));
+        commandExtractedSectionDescriptionLabel.putClientProperty("html.disable", null);
 
         commandExtractedAccessKeyLabel.setFont(commandExtractedAccessKeyLabel.getFont().deriveFont(commandExtractedAccessKeyLabel.getFont().getStyle() | java.awt.Font.BOLD, commandExtractedAccessKeyLabel.getFont().getSize()+1));
         commandExtractedAccessKeyLabel.setLabelFor(commandExtractedAccessKeyTextField);


### PR DESCRIPTION
Burp Suite version 2022.3 and beyond disables HTML rendering in Swing elements' text by default. Need to opt in with `.putClientProperty("html.disable", null);`. This has been added to the components which use HTML for text formatting and tested with Burp Suite v2022.3.2.