### PR TITLE
Fixed regular expression for header matchin - SignedHeaders field is …

### DIFF
--- a/src/main/java/com/netspi/awssigner/signing/ParsedAuthHeader.java
+++ b/src/main/java/com/netspi/awssigner/signing/ParsedAuthHeader.java
@@ -15,7 +15,7 @@ public class ParsedAuthHeader {
     private static final String AUTH_HEADER_PATTERN_SERVICE_GROUP = "service";
     private static final String AUTH_HEADER_PATTERN_SIGNED_HEADERS_GROUP = "signedheaders";
     private static final String AUTH_HEADER_PATTERN_SIGNATURE_GROUP = "signature";
-    private static final Pattern AUTH_HEADER_PATTERN = Pattern.compile("Authorization:\\s*(?<" + AUTH_HEADER_PATTERN_ALGORITHM_GROUP + ">AWS4-(?:HMAC|ECDSA-P256)-SHA256)\\s*Credential=(?<" + AUTH_HEADER_PATTERN_ACCESS_KEY_GROUP + ">[\\w-]{1,128})\\/(?<" + AUTH_HEADER_PATTERN_DATE_GROUP + ">\\d{8})\\/(?:(?<" + AUTH_HEADER_PATTERN_REGION_GROUP + ">[\\w-]{0,64})\\/)?(?<" + AUTH_HEADER_PATTERN_SERVICE_GROUP + ">\\S{0,128})\\/aws4_request,?\\s+SignedHeaders=(?<" + AUTH_HEADER_PATTERN_SIGNED_HEADERS_GROUP + ">\\S+),?\\s+Signature=(?<" + AUTH_HEADER_PATTERN_SIGNATURE_GROUP + ">[a-fA-F\\d]{1,256})", Pattern.CASE_INSENSITIVE);
+    private static final Pattern AUTH_HEADER_PATTERN = Pattern.compile("Authorization:\\s*(?<" + AUTH_HEADER_PATTERN_ALGORITHM_GROUP + ">AWS4-(?:HMAC|ECDSA-P256)-SHA256)\\s*Credential=(?<" + AUTH_HEADER_PATTERN_ACCESS_KEY_GROUP + ">[\\w-]{1,128})\\/(?<" + AUTH_HEADER_PATTERN_DATE_GROUP + ">\\d{8})\\/(?:(?<" + AUTH_HEADER_PATTERN_REGION_GROUP + ">[\\w-]{0,64})\\/)?(?<" + AUTH_HEADER_PATTERN_SERVICE_GROUP + ">\\S{0,128})\\/aws4_request(,|\\s)+SignedHeaders=(?<" + AUTH_HEADER_PATTERN_SIGNED_HEADERS_GROUP + ">\\S+)(,|\\s)+Signature=(?<" + AUTH_HEADER_PATTERN_SIGNATURE_GROUP + ">[a-fA-F\\d]{1,256})", Pattern.CASE_INSENSITIVE);
 
     private final SigningAlgorithm algorithm;
     private final String accessKey;

--- a/src/main/java/com/netspi/awssigner/signing/ParsedAuthHeader.java
+++ b/src/main/java/com/netspi/awssigner/signing/ParsedAuthHeader.java
@@ -15,7 +15,7 @@ public class ParsedAuthHeader {
     private static final String AUTH_HEADER_PATTERN_SERVICE_GROUP = "service";
     private static final String AUTH_HEADER_PATTERN_SIGNED_HEADERS_GROUP = "signedheaders";
     private static final String AUTH_HEADER_PATTERN_SIGNATURE_GROUP = "signature";
-    private static final Pattern AUTH_HEADER_PATTERN = Pattern.compile("Authorization:\\s*(?<" + AUTH_HEADER_PATTERN_ALGORITHM_GROUP + ">AWS4-(?:HMAC|ECDSA-P256)-SHA256)\\s*Credential=(?<" + AUTH_HEADER_PATTERN_ACCESS_KEY_GROUP + ">[\\w-]{1,128})\\/(?<" + AUTH_HEADER_PATTERN_DATE_GROUP + ">\\d{8})\\/(?:(?<" + AUTH_HEADER_PATTERN_REGION_GROUP + ">[\\w-]{0,64})\\/)?(?<" + AUTH_HEADER_PATTERN_SERVICE_GROUP + ">\\S{0,128})\\/aws4_request,?\\s+SignedHeaders=(?<" + AUTH_HEADER_PATTERN_SIGNED_HEADERS_GROUP + ">\\S+),\\s+Signature=(?<" + AUTH_HEADER_PATTERN_SIGNATURE_GROUP + ">[a-fA-F\\d]{1,256})", Pattern.CASE_INSENSITIVE);
+    private static final Pattern AUTH_HEADER_PATTERN = Pattern.compile("Authorization:\\s*(?<" + AUTH_HEADER_PATTERN_ALGORITHM_GROUP + ">AWS4-(?:HMAC|ECDSA-P256)-SHA256)\\s*Credential=(?<" + AUTH_HEADER_PATTERN_ACCESS_KEY_GROUP + ">[\\w-]{1,128})\\/(?<" + AUTH_HEADER_PATTERN_DATE_GROUP + ">\\d{8})\\/(?:(?<" + AUTH_HEADER_PATTERN_REGION_GROUP + ">[\\w-]{0,64})\\/)?(?<" + AUTH_HEADER_PATTERN_SERVICE_GROUP + ">\\S{0,128})\\/aws4_request,?\\s+SignedHeaders=(?<" + AUTH_HEADER_PATTERN_SIGNED_HEADERS_GROUP + ">\\S+),?\\s+Signature=(?<" + AUTH_HEADER_PATTERN_SIGNATURE_GROUP + ">[a-fA-F\\d]{1,256})", Pattern.CASE_INSENSITIVE);
 
     private final SigningAlgorithm algorithm;
     private final String accessKey;


### PR DESCRIPTION
There is a small bug in the regular expression used, preventing AWS Signer to properly [re]sign the requests passing through the proxy/repeater/....
The "SignedHeaders" field in the Authorization header is not necessarily comma terminated.
Hence, added the optional question mark.