### PR TITLE
Add support for per-tool signing configuration, configuration saving + minor bug fixes

### DIFF
--- a/src/main/java/burp/BurpExtender.java
+++ b/src/main/java/burp/BurpExtender.java
@@ -11,7 +11,10 @@ import com.netspi.awssigner.signing.SigningException;
 import com.netspi.awssigner.view.BurpUIComponentCustomizer;
 import com.netspi.awssigner.view.BurpTabPanel;
 import java.awt.Component;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import javax.swing.JMenuItem;
 import javax.swing.SwingUtilities;
@@ -19,7 +22,23 @@ import javax.swing.SwingUtilities;
 //This is the Burp primary class. It needs to live in this package and have this name
 public class BurpExtender implements IBurpExtender, ITab, IHttpListener, IContextMenuFactory {
 
+    static {
+        final Map<Integer, String> tempMap = new HashMap<Integer, String>();
+
+        tempMap.put(IBurpExtenderCallbacks.TOOL_SUITE, "All");
+        tempMap.put(IBurpExtenderCallbacks.TOOL_EXTENDER, "Extensions");
+        tempMap.put(IBurpExtenderCallbacks.TOOL_INTRUDER, "Intruder");
+        tempMap.put(IBurpExtenderCallbacks.TOOL_PROXY, "Proxy");
+        tempMap.put(IBurpExtenderCallbacks.TOOL_REPEATER, "Repeater");
+        tempMap.put(IBurpExtenderCallbacks.TOOL_SCANNER, "Scanner");
+        tempMap.put(IBurpExtenderCallbacks.TOOL_SEQUENCER, "Sequencer");
+        tempMap.put(IBurpExtenderCallbacks.TOOL_TARGET, "Target");
+
+        TOOL_FLAG_TRANSLATION_MAP = Collections.unmodifiableMap(tempMap);
+    }
     public static final String EXTENSION_NAME = "AWS Signer";
+
+    private static final Map<Integer, String> TOOL_FLAG_TRANSLATION_MAP;
 
     private BurpTabPanel view;
     private AWSSignerConfiguration model;
@@ -96,6 +115,12 @@ public class BurpExtender implements IBurpExtender, ITab, IHttpListener, IContex
         //Is the signer enabled?
         if (!model.isEnabled) {
             LogWriter.logDebug("Signing not enabled. Ignoring Message.");
+            return;
+        }
+
+        // Is the request from a tool we want to sign?
+        if ((model.signForTools & toolFlag) == 0 && (model.signForTools & IBurpExtenderCallbacks.TOOL_SUITE) == 0) {
+            LogWriter.logDebug("Signing for requests from " + TOOL_FLAG_TRANSLATION_MAP.get(toolFlag) + " is not enabled. Ignoring Message.");
             return;
         }
 

--- a/src/main/java/burp/BurpExtender.java
+++ b/src/main/java/burp/BurpExtender.java
@@ -8,6 +8,7 @@ import com.netspi.awssigner.model.Profile;
 import com.netspi.awssigner.signing.DelegatingAwsRequestSigner;
 import com.netspi.awssigner.signing.ParsedAuthHeader;
 import com.netspi.awssigner.signing.SigningException;
+import com.netspi.awssigner.utils.AWSSignerUtils;
 import com.netspi.awssigner.view.BurpUIComponentCustomizer;
 import com.netspi.awssigner.view.BurpTabPanel;
 import java.awt.Component;
@@ -52,7 +53,13 @@ public class BurpExtender implements IBurpExtender, ITab, IHttpListener, IContex
 
         //Save callbacks and helpers for later reference
         this.callbacks = callbacks;
+        AWSSignerUtils.setBurpExtenderCallbacks(callbacks);
         helpers = callbacks.getHelpers();
+
+        // Extension unload/shutdown callback
+        this.callbacks.registerExtensionStateListener(()-> {
+            this.model.persist();
+        });
 
         //Setup styling
         BurpUIComponentCustomizer.setBurpStyler((Component component) -> {
@@ -66,7 +73,7 @@ public class BurpExtender implements IBurpExtender, ITab, IHttpListener, IContex
         //Create the view
         view = new BurpTabPanel();
         //Create the model
-        model = new AWSSignerConfiguration();
+        model = AWSSignerConfiguration.getOrCreateProjectConfiguration();
         //Create controller to keep them in sync
         controller = new AWSSignerController(view, model);
 

--- a/src/main/java/com/netspi/awssigner/controller/AWSSignerController.java
+++ b/src/main/java/com/netspi/awssigner/controller/AWSSignerController.java
@@ -1,6 +1,7 @@
 package com.netspi.awssigner.controller;
 
 import burp.BurpExtender;
+import burp.IBurpExtenderCallbacks;
 import burp.IContextMenuInvocation;
 import com.netspi.awssigner.credentials.SigningCredentials;
 import com.google.gson.GsonBuilder;
@@ -95,6 +96,62 @@ public class AWSSignerController {
                 LogWriter.setLevel(newLoggingLevel);
             }
         }));
+
+        //Sign for all check box
+        view.signForAllCheckbox.addItemListener((ItemEvent e) -> {
+            logDebug("signForTools before: " + Integer.toBinaryString(model.signForTools));
+            model.signForTools = model.signForTools ^ IBurpExtenderCallbacks.TOOL_SUITE;
+            logDebug("signForTools after: " + Integer.toBinaryString(model.signForTools));
+        });
+        
+        //Sign for repeater check box
+        view.signForRepeaterCheckbox.addItemListener((ItemEvent e) -> {
+            logDebug("signForTools before: " + Integer.toBinaryString(model.signForTools));
+            model.signForTools = model.signForTools ^ IBurpExtenderCallbacks.TOOL_REPEATER;
+            logDebug("signForTools after: " + Integer.toBinaryString(model.signForTools));
+        });
+
+        //Sign for proxy check box
+        view.signForProxyCheckbox.addItemListener((ItemEvent e) -> {
+            logDebug("signForTools before: " + Integer.toBinaryString(model.signForTools));
+            model.signForTools = model.signForTools ^ IBurpExtenderCallbacks.TOOL_PROXY;
+            logDebug("signForTools after: " + Integer.toBinaryString(model.signForTools));
+        });
+
+        //Sign for intruder check box
+        view.signForIntruderCheckbox.addItemListener((ItemEvent e) -> {
+            logDebug("signForTools before: " + Integer.toBinaryString(model.signForTools));
+            model.signForTools = model.signForTools ^ IBurpExtenderCallbacks.TOOL_INTRUDER;
+            logDebug("signForTools after: " + Integer.toBinaryString(model.signForTools));
+        });
+
+        //Sign target check box
+        view.signForTargetCheckbox.addItemListener((ItemEvent e) -> {
+            logDebug("signForTools before: " + Integer.toBinaryString(model.signForTools));
+            model.signForTools = model.signForTools ^ IBurpExtenderCallbacks.TOOL_TARGET;
+            logDebug("signForTools after: " + Integer.toBinaryString(model.signForTools));
+        });
+
+        //Sign for extensions check box
+        view.signForExtensionsCheckbox.addItemListener((ItemEvent e) -> {
+            logDebug("signForTools before: " + Integer.toBinaryString(model.signForTools));
+            model.signForTools = model.signForTools ^ IBurpExtenderCallbacks.TOOL_EXTENDER;
+            logDebug("signForTools after: " + Integer.toBinaryString(model.signForTools));
+        });
+
+        //Sign for sequencer check box
+        view.signForSequencerCheckbox.addItemListener((ItemEvent e) -> {
+            logDebug("signForTools before: " + Integer.toBinaryString(model.signForTools));
+            model.signForTools = model.signForTools ^ IBurpExtenderCallbacks.TOOL_SEQUENCER;
+            logDebug("signForTools after: " + Integer.toBinaryString(model.signForTools));
+        });
+
+        //Sign for scanner check box
+        view.signForScannerCheckbox.addItemListener((ItemEvent e) -> {
+            logDebug("signForTools before: " + Integer.toBinaryString(model.signForTools));
+            model.signForTools = model.signForTools ^ IBurpExtenderCallbacks.TOOL_SCANNER;
+            logDebug("signForTools after: " + Integer.toBinaryString(model.signForTools));
+        });
 
         //Add button
         view.addProfileButton.addActionListener(((ActionEvent e) -> {

--- a/src/main/java/com/netspi/awssigner/controller/AWSSignerController.java
+++ b/src/main/java/com/netspi/awssigner/controller/AWSSignerController.java
@@ -34,7 +34,6 @@ import com.netspi.awssigner.view.ImportDialog;
 import java.awt.Component;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
-import java.awt.event.MouseListener;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -325,6 +324,31 @@ public class AWSSignerController {
             }
 
             Profile profile = currentProfileOptional.get();
+
+            // Bug fix to use the updated config if the input text field still has focus
+            if (profile instanceof StaticCredentialsProfile) {
+                if (view.staticAccessKeyTextField.hasFocus()) {
+                    ((StaticCredentialsProfile) profile).setAccessKey(view.staticAccessKeyTextField.getText());
+                }
+                if (view.staticSecretKeyTextField.hasFocus()) {
+                    ((StaticCredentialsProfile) profile).setSecretKey(view.staticSecretKeyTextField.getText());
+                }
+                if (view.staticSessionTokenTextField.hasFocus()) {
+                    ((StaticCredentialsProfile) profile).setSessionToken(view.staticSessionTokenTextField.getText());
+                }
+            } else if (profile instanceof CommandProfile) {
+                if (view.commandCommandTextField.hasFocus()) {
+                    ((CommandProfile) profile).setCommand(view.commandCommandTextField.getText());
+                }
+                if (view.commandDurationTextField.hasFocus()) {
+                    ((CommandProfile) profile).setDurationSecondsFromText(view.commandDurationTextField.getText());
+                }
+            } else if ( profile instanceof AssumeRoleProfile) {
+                if (view.assumeRoleRoleArnTextField.hasFocus()) {
+                    ((AssumeRoleProfile) profile).setRoleArn(view.assumeRoleRoleArnTextField.getText());
+                }
+            }
+
             //Check if we even have enough information to test this profile
             if (!profile.requiredFieldsAreSet()) {
                 logDebug("Profile " + profile.getName() + " does not have all required fields");

--- a/src/main/java/com/netspi/awssigner/controller/AWSSignerController.java
+++ b/src/main/java/com/netspi/awssigner/controller/AWSSignerController.java
@@ -66,8 +66,42 @@ public class AWSSignerController {
 
         initListeners();
 
-        //Add the initial profile
-        addProfile(new StaticCredentialsProfile(INIT_PROFILE_NAME));
+        //Add the initial profile if no profiles exist already
+
+        if (this.model.profiles.isEmpty()) {
+            addProfile(new StaticCredentialsProfile(INIT_PROFILE_NAME));
+        } else {
+            this.view.profileList.setSelectedIndex(0);
+        }
+
+        syncViewWithModel();
+    }
+
+    private void syncViewWithModel(){
+
+        //Setup profile list
+        DefaultListModel listModel = resetProfileList();
+        view.profileList.setSelectedIndex(0);
+
+        //Reset "Always Sign With" combo box
+        resetAlwaysSignWithProfileComboBox();
+
+        initializeProfileConfigurationTab(model.profiles.get(0));
+
+        // Hack to preserve the state of the flag bits, since the handlers for setSelected flip the bits currently.
+        
+        int tmp = model.signForTools;
+        this.view.persistConfigurationCheckbox.setSelected(model.shouldPersist);
+        this.view.signingEnabledCheckbox.setSelected(model.isEnabled);
+        this.view.signForAllCheckbox.setSelected((model.signForTools & IBurpExtenderCallbacks.TOOL_SUITE) != 0);
+        this.view.signForProxyCheckbox.setSelected((model.signForTools & IBurpExtenderCallbacks.TOOL_PROXY) != 0);
+        this.view.signForIntruderCheckbox.setSelected((model.signForTools & IBurpExtenderCallbacks.TOOL_INTRUDER) != 0);
+        this.view.signForExtensionsCheckbox.setSelected((model.signForTools & IBurpExtenderCallbacks.TOOL_EXTENDER) != 0);
+        this.view.signForRepeaterCheckbox.setSelected((model.signForTools & IBurpExtenderCallbacks.TOOL_REPEATER) != 0);
+        this.view.signForTargetCheckbox.setSelected((model.signForTools & IBurpExtenderCallbacks.TOOL_TARGET) != 0);
+        this.view.signForScannerCheckbox.setSelected((model.signForTools & IBurpExtenderCallbacks.TOOL_SCANNER) != 0);
+        this.view.signForSequencerCheckbox.setSelected((model.signForTools & IBurpExtenderCallbacks.TOOL_SEQUENCER) != 0);
+        model.signForTools = tmp;
     }
 
     private void initListeners() {
@@ -76,6 +110,13 @@ public class AWSSignerController {
             logDebug("Global Signing Enabled Checkbox State Change.");
             model.isEnabled = (e.getStateChange() == ItemEvent.SELECTED);
             logInfo("Signing Enabled: " + model.isEnabled);
+        });
+
+        //Configuration persistence checkbox
+        view.persistConfigurationCheckbox.addItemListener((ItemEvent e) -> {
+            logDebug("Persist Configuration Checkbox State Change.");
+            model.shouldPersist = (e.getStateChange() == ItemEvent.SELECTED);
+            logInfo("Persist Configuration Enabled: " + model.shouldPersist);
         });
 
         //"Always Sign With" profile selection combox box

--- a/src/main/java/com/netspi/awssigner/model/AWSSignerConfiguration.java
+++ b/src/main/java/com/netspi/awssigner/model/AWSSignerConfiguration.java
@@ -1,17 +1,42 @@
 package com.netspi.awssigner.model;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+import com.netspi.awssigner.utils.AWSSignerUtils;
+
 import burp.IBurpExtenderCallbacks;
 
-public class AWSSignerConfiguration {
+public class AWSSignerConfiguration implements Serializable {
     public volatile boolean isEnabled =  true;
     public volatile List<Profile> profiles = new ArrayList<>();
     public volatile Profile alwaysSignWithProfile;
     public volatile int signForTools = IBurpExtenderCallbacks.TOOL_SUITE;
+    public volatile boolean shouldPersist = true;
+
+    public static final String PREFERENCE_KEY_SUFFIX = "aws-signer-configuration";
+
+    public synchronized void persist() {
+        if (shouldPersist) {
+            AWSSignerUtils.storeObjectForCurrentProject(PREFERENCE_KEY_SUFFIX, this);
+        }
+    }
+
+    public static AWSSignerConfiguration getOrCreateProjectConfiguration() {
+
+        AWSSignerConfiguration config = new AWSSignerConfiguration();
+
+        Object o = AWSSignerUtils.getStoredObjectForCurrentProject(PREFERENCE_KEY_SUFFIX);
+
+        if ( o != null && o instanceof AWSSignerConfiguration) {
+            config = (AWSSignerConfiguration) o;
+        }
+
+        return config;
+    }
 
     public List<String> getProfileNames() {
         return profiles.stream().map(Profile::getName).collect(Collectors.toList());

--- a/src/main/java/com/netspi/awssigner/model/AWSSignerConfiguration.java
+++ b/src/main/java/com/netspi/awssigner/model/AWSSignerConfiguration.java
@@ -5,10 +5,13 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+import burp.IBurpExtenderCallbacks;
+
 public class AWSSignerConfiguration {
     public volatile boolean isEnabled =  true;
     public volatile List<Profile> profiles = new ArrayList<>();
     public volatile Profile alwaysSignWithProfile;
+    public volatile int signForTools = IBurpExtenderCallbacks.TOOL_SUITE;
 
     public List<String> getProfileNames() {
         return profiles.stream().map(Profile::getName).collect(Collectors.toList());

--- a/src/main/java/com/netspi/awssigner/model/AWSSignerConfiguration.java
+++ b/src/main/java/com/netspi/awssigner/model/AWSSignerConfiguration.java
@@ -17,11 +17,11 @@ public class AWSSignerConfiguration implements Serializable {
     public volatile int signForTools = IBurpExtenderCallbacks.TOOL_SUITE;
     public volatile boolean shouldPersist = true;
 
-    public static final String PREFERENCE_KEY_SUFFIX = "aws-signer-configuration";
+    public static final String STORED_CONFIG_OBJECT_KEY = "aws-signer-configuration";
 
     public synchronized void persist() {
         if (shouldPersist) {
-            AWSSignerUtils.storeObjectForCurrentProject(PREFERENCE_KEY_SUFFIX, this);
+            AWSSignerUtils.storeObjectForCurrentProject(STORED_CONFIG_OBJECT_KEY, this);
         }
     }
 
@@ -29,7 +29,7 @@ public class AWSSignerConfiguration implements Serializable {
 
         AWSSignerConfiguration config = new AWSSignerConfiguration();
 
-        Object o = AWSSignerUtils.getStoredObjectForCurrentProject(PREFERENCE_KEY_SUFFIX);
+        Object o = AWSSignerUtils.getStoredObjectForCurrentProject(STORED_CONFIG_OBJECT_KEY);
 
         if ( o != null && o instanceof AWSSignerConfiguration) {
             config = (AWSSignerConfiguration) o;

--- a/src/main/java/com/netspi/awssigner/model/Profile.java
+++ b/src/main/java/com/netspi/awssigner/model/Profile.java
@@ -2,10 +2,12 @@ package com.netspi.awssigner.model;
 
 import com.netspi.awssigner.credentials.SignerCredentialException;
 import com.netspi.awssigner.credentials.SigningCredentials;
+
+import java.io.Serializable;
 import java.util.Objects;
 import java.util.Optional;
 
-public abstract class Profile {
+public abstract class Profile implements Serializable {
 
     protected String name;
     protected boolean isEnabled = true;

--- a/src/main/java/com/netspi/awssigner/utils/AWSSignerUtils.java
+++ b/src/main/java/com/netspi/awssigner/utils/AWSSignerUtils.java
@@ -1,0 +1,153 @@
+package com.netspi.awssigner.utils;
+
+import com.netspi.awssigner.log.LogWriter;
+
+import burp.IBurpExtenderCallbacks;
+import burp.IHttpRequestResponse;
+import burp.IHttpService;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.net.URL;
+import java.util.Base64;
+import java.util.UUID;
+
+public final class AWSSignerUtils {
+    private static String PREFERENCES_URL_STRING = "aws-signer-project-preferences";
+
+    private static IBurpExtenderCallbacks callbacks;
+    private static IHttpService httpService;
+
+    public static void setBurpExtenderCallbacks(IBurpExtenderCallbacks callbacks) {
+        AWSSignerUtils.callbacks = callbacks;
+        httpService = callbacks.getHelpers().buildHttpService(PREFERENCES_URL_STRING, 65535, true);
+    }
+
+    public static Object getStoredObjectForCurrentProject(String key) {
+        String projectUUIDString = getOrGenerateProjectUUID();
+        LogWriter.logDebug("Project UUID string is: " + projectUUIDString);
+
+        String base64 = callbacks.loadExtensionSetting(projectUUIDString+ "-" + key);
+
+        Object result = null;
+
+        if ( base64 != null ){
+            try {
+                ObjectInputStream ois = new ObjectInputStream(new ByteArrayInputStream(Base64.getDecoder().decode(base64)));
+    
+                result = ois.readObject();
+            } catch ( Exception e ) {
+                e.printStackTrace();
+            }
+        }
+
+        return result;
+    }
+
+    public static void storeObjectForCurrentProject(String key, Object value) {
+        String projectUUIDString = getOrGenerateProjectUUID();
+        LogWriter.logDebug("Project UUID string is: " + projectUUIDString);
+
+        try {
+
+            ByteArrayOutputStream outputBuffer = new ByteArrayOutputStream();
+            ObjectOutputStream oos = new ObjectOutputStream(outputBuffer);
+            oos.writeObject(value);
+
+            byte[] serializedObject = outputBuffer.toByteArray();
+
+            String base64 = Base64.getEncoder().encodeToString(serializedObject);
+
+            callbacks.saveExtensionSetting(projectUUIDString + "-" + key, base64);            
+        } catch ( Exception e ) {
+            e.printStackTrace();
+        }
+    }
+
+    private static String getOrGenerateProjectUUID() {
+        IHttpRequestResponse[] sitemap = callbacks.getSiteMap(httpService.getProtocol() +"://" + httpService.getHost() + ":" + httpService.getPort() + "/" + PREFERENCES_URL_STRING);
+
+        String uuidString = null;
+
+        if (sitemap.length == 0) {
+            uuidString = UUID.randomUUID().toString();
+            HttpResponseWrapper uuid = new HttpResponseWrapper();
+
+            try {
+                byte[] buffer = callbacks.getHelpers().buildHttpRequest(new URL(httpService.getProtocol(), httpService.getHost(), httpService.getPort(), "/" + PREFERENCES_URL_STRING));
+
+
+                uuid.setRequest(buffer);
+                uuid.setResponse(uuidString.getBytes());
+                uuid.setHttpService(httpService);
+
+                uuid.setRequest(buffer);
+                callbacks.addToSiteMap(uuid);
+            } catch ( Exception e ){
+                
+                e.printStackTrace();
+            }
+        } else {
+            uuidString = new String(sitemap[0].getResponse());
+        }
+
+        LogWriter.logDebug("Using project UUID: " + uuidString);
+
+        return uuidString;
+    }
+
+    static class HttpResponseWrapper implements IHttpRequestResponse {
+
+        private byte[] requestData;
+        private byte[] responseData;
+        private IHttpService service;
+
+        @Override
+        public byte[] getRequest() {
+            return requestData;
+        }
+
+        @Override
+        public void setRequest(byte[] message) {
+            this.requestData = message;
+        }
+
+        @Override
+        public byte[] getResponse() {
+            return responseData;
+        }
+
+        @Override
+        public void setResponse(byte[] message) {
+            this.responseData = message;
+        }
+
+        @Override
+        public String getComment() {
+            return null;
+        }
+
+        @Override
+        public void setComment(String comment) {}
+
+        @Override
+        public String getHighlight() {
+            return null;
+        }
+
+        @Override
+        public void setHighlight(String color) {}
+
+        @Override
+        public IHttpService getHttpService() {
+            return service;
+        }
+
+        @Override
+        public void setHttpService(IHttpService httpService) {
+            this.service = httpService;
+        }
+    }
+}

--- a/src/main/java/com/netspi/awssigner/view/BurpTabPanel.form
+++ b/src/main/java/com/netspi/awssigner/view/BurpTabPanel.form
@@ -95,49 +95,59 @@
       <Layout>
         <DimensionLayout dim="0">
           <Group type="103" groupAlignment="0" attributes="0">
-              <Group type="102" alignment="0" attributes="0">
+              <Component id="globalSettingsSeparator" alignment="0" max="32767" attributes="0"/>
+              <Group type="102" attributes="0">
                   <EmptySpace min="-2" max="-2" attributes="0"/>
                   <Group type="103" groupAlignment="0" attributes="0">
-                      <Component id="globalSettingsLabel" min="-2" max="-2" attributes="0"/>
                       <Group type="102" alignment="0" attributes="0">
                           <EmptySpace min="-2" pref="10" max="-2" attributes="0"/>
                           <Group type="103" groupAlignment="0" attributes="0">
-                              <Component id="globalSettingsDescriptionLabel" min="-2" max="-2" attributes="0"/>
+                              <Component id="globalSettingsDescriptionLabel" alignment="0" min="-2" max="-2" attributes="0"/>
                               <Group type="102" alignment="0" attributes="0">
+                                  <Component id="persistConfigurationCheckbox" min="-2" max="-2" attributes="0"/>
+                                  <EmptySpace max="-2" attributes="0"/>
                                   <Component id="signingEnabledCheckbox" min="-2" max="-2" attributes="0"/>
                                   <EmptySpace type="unrelated" min="-2" max="-2" attributes="0"/>
                                   <Component id="alwaysSignWithProfileLabel" min="-2" max="-2" attributes="0"/>
                                   <EmptySpace max="-2" attributes="0"/>
                                   <Component id="alwaysSignWithProfileComboBox" min="-2" pref="349" max="-2" attributes="0"/>
-                                  <EmptySpace type="unrelated" max="-2" attributes="0"/>
+                                  <EmptySpace max="-2" attributes="0"/>
                                   <Component id="logLevelLabel" min="-2" max="-2" attributes="0"/>
                                   <EmptySpace max="-2" attributes="0"/>
                                   <Component id="logLevelComboBox" min="-2" max="-2" attributes="0"/>
                               </Group>
                           </Group>
                       </Group>
+                      <Component id="globalSettingsLabel" alignment="0" min="-2" max="-2" attributes="0"/>
                   </Group>
-                  <EmptySpace min="248" pref="391" max="32767" attributes="0"/>
+                  <EmptySpace max="-2" attributes="0"/>
+                  <Component id="signForPanel" min="-2" max="-2" attributes="0"/>
+                  <EmptySpace pref="155" max="32767" attributes="0"/>
               </Group>
-              <Component id="globalSettingsSeparator" alignment="0" max="32767" attributes="0"/>
           </Group>
         </DimensionLayout>
         <DimensionLayout dim="1">
           <Group type="103" groupAlignment="0" attributes="0">
               <Group type="102" alignment="0" attributes="0">
-                  <EmptySpace max="32767" attributes="0"/>
-                  <Component id="globalSettingsLabel" min="-2" max="-2" attributes="0"/>
-                  <EmptySpace max="-2" attributes="0"/>
-                  <Component id="globalSettingsDescriptionLabel" min="-2" max="-2" attributes="0"/>
-                  <EmptySpace type="unrelated" max="-2" attributes="0"/>
-                  <Group type="103" groupAlignment="3" attributes="0">
-                      <Component id="signingEnabledCheckbox" alignment="3" min="-2" max="-2" attributes="0"/>
-                      <Component id="alwaysSignWithProfileLabel" alignment="3" min="-2" max="-2" attributes="0"/>
-                      <Component id="alwaysSignWithProfileComboBox" alignment="3" min="-2" max="-2" attributes="0"/>
-                      <Component id="logLevelLabel" alignment="3" min="-2" max="-2" attributes="0"/>
-                      <Component id="logLevelComboBox" alignment="3" min="-2" max="-2" attributes="0"/>
+                  <Group type="103" groupAlignment="0" attributes="0">
+                      <Group type="102" attributes="0">
+                          <EmptySpace max="32767" attributes="0"/>
+                          <Component id="globalSettingsLabel" min="-2" max="-2" attributes="0"/>
+                          <EmptySpace min="-2" pref="12" max="-2" attributes="0"/>
+                          <Component id="globalSettingsDescriptionLabel" min="-2" max="-2" attributes="0"/>
+                          <EmptySpace type="unrelated" max="-2" attributes="0"/>
+                          <Group type="103" groupAlignment="3" attributes="0">
+                              <Component id="signingEnabledCheckbox" alignment="3" min="-2" max="-2" attributes="0"/>
+                              <Component id="alwaysSignWithProfileLabel" alignment="3" min="-2" max="-2" attributes="0"/>
+                              <Component id="alwaysSignWithProfileComboBox" alignment="3" min="-2" max="-2" attributes="0"/>
+                              <Component id="logLevelLabel" alignment="3" min="-2" max="-2" attributes="0"/>
+                              <Component id="logLevelComboBox" alignment="3" min="-2" max="-2" attributes="0"/>
+                              <Component id="persistConfigurationCheckbox" alignment="3" min="-2" max="-2" attributes="0"/>
+                          </Group>
+                      </Group>
+                      <Component id="signForPanel" alignment="1" max="32767" attributes="0"/>
                   </Group>
-                  <EmptySpace max="-2" attributes="0"/>
+                  <EmptySpace min="103" pref="103" max="-2" attributes="0"/>
                   <Component id="globalSettingsSeparator" min="-2" max="-2" attributes="0"/>
                   <EmptySpace min="-2" pref="8" max="-2" attributes="0"/>
               </Group>
@@ -165,7 +175,8 @@
                 <Font component="globalSettingsDescriptionLabel" property="font" relativeSize="true" size="0"/>
               </FontInfo>
             </Property>
-            <Property name="text" type="java.lang.String" value="&lt;html&gt;Change extension behavior. Set &lt;i&gt;Always Sign With&lt;/i&gt; to force signing of all requests with the specified profile credentials."/>
+            <Property name="text" type="java.lang.String" value="&lt;html&gt;Change extension behavior. Set &lt;i&gt;Always Sign With&lt;/i&gt; to force signing
+ of all requests with the specified profile credentials."/>
           </Properties>
           <AuxValues>
             <AuxValue name="JavaCodeGenerator_InitCodePost" type="java.lang.String" value="globalSettingsDescriptionLabel.putClientProperty(&quot;html.disable&quot;, null);"/>
@@ -180,7 +191,7 @@
             </Property>
             <Property name="selected" type="boolean" value="true"/>
             <Property name="text" type="java.lang.String" value="Signing Enabled"/>
-            <Property name="toolTipText" type="java.lang.String" value="Enable/Disable request signing globally"/>
+            <Property name="toolTipText" type="java.lang.String" value="Enable/Disable request signing globally."/>
             <Property name="horizontalTextPosition" type="int" value="10"/>
           </Properties>
           <AuxValues>
@@ -254,6 +265,212 @@
           </AuxValues>
         </Component>
         <Component class="javax.swing.JSeparator" name="globalSettingsSeparator">
+        </Component>
+        <Container class="javax.swing.JPanel" name="signForPanel">
+
+          <Layout>
+            <DimensionLayout dim="0">
+              <Group type="103" groupAlignment="0" attributes="0">
+                  <Group type="102" attributes="0">
+                      <EmptySpace max="-2" attributes="0"/>
+                      <Group type="103" groupAlignment="0" attributes="0">
+                          <Component id="signForLabel" alignment="0" min="-2" max="-2" attributes="0"/>
+                          <Group type="102" alignment="0" attributes="0">
+                              <Group type="103" groupAlignment="0" attributes="0">
+                                  <Component id="signForAllCheckbox" alignment="0" min="-2" max="-2" attributes="0"/>
+                                  <Component id="signForProxyCheckbox" alignment="0" min="-2" max="-2" attributes="0"/>
+                              </Group>
+                              <EmptySpace max="-2" attributes="0"/>
+                              <Group type="103" groupAlignment="0" attributes="0">
+                                  <Group type="102" alignment="0" attributes="0">
+                                      <Component id="signForRepeaterCheckbox" min="-2" max="-2" attributes="0"/>
+                                      <EmptySpace max="-2" attributes="0"/>
+                                      <Component id="signForExtensionsCheckbox" min="-2" max="-2" attributes="0"/>
+                                  </Group>
+                                  <Group type="102" alignment="0" attributes="0">
+                                      <Component id="signForIntruderCheckbox" min="-2" max="-2" attributes="0"/>
+                                      <EmptySpace type="unrelated" max="-2" attributes="0"/>
+                                      <Component id="signForTargetCheckbox" min="-2" max="-2" attributes="0"/>
+                                  </Group>
+                              </Group>
+                              <EmptySpace max="-2" attributes="0"/>
+                              <Group type="103" groupAlignment="0" attributes="0">
+                                  <Component id="signForSequencerCheckbox" min="-2" max="-2" attributes="0"/>
+                                  <Component id="signForScannerCheckbox" min="-2" max="-2" attributes="0"/>
+                              </Group>
+                          </Group>
+                      </Group>
+                      <EmptySpace pref="28" max="32767" attributes="0"/>
+                  </Group>
+              </Group>
+            </DimensionLayout>
+            <DimensionLayout dim="1">
+              <Group type="103" groupAlignment="0" attributes="0">
+                  <Group type="102" alignment="0" attributes="0">
+                      <EmptySpace max="32767" attributes="0"/>
+                      <Component id="signForLabel" min="-2" max="-2" attributes="0"/>
+                      <EmptySpace max="-2" attributes="0"/>
+                      <Group type="103" groupAlignment="3" attributes="0">
+                          <Component id="signForAllCheckbox" alignment="3" min="-2" max="-2" attributes="0"/>
+                          <Component id="signForRepeaterCheckbox" alignment="3" min="-2" max="-2" attributes="0"/>
+                          <Component id="signForExtensionsCheckbox" alignment="3" min="-2" max="-2" attributes="0"/>
+                          <Component id="signForScannerCheckbox" alignment="3" min="-2" max="-2" attributes="0"/>
+                      </Group>
+                      <EmptySpace max="-2" attributes="0"/>
+                      <Group type="103" groupAlignment="3" attributes="0">
+                          <Component id="signForProxyCheckbox" alignment="3" min="-2" max="-2" attributes="0"/>
+                          <Component id="signForIntruderCheckbox" alignment="3" min="-2" max="-2" attributes="0"/>
+                          <Component id="signForTargetCheckbox" alignment="3" min="-2" max="-2" attributes="0"/>
+                          <Component id="signForSequencerCheckbox" alignment="3" min="-2" max="-2" attributes="0"/>
+                      </Group>
+                  </Group>
+              </Group>
+            </DimensionLayout>
+          </Layout>
+          <SubComponents>
+            <Component class="javax.swing.JLabel" name="signForLabel">
+              <Properties>
+                <Property name="text" type="java.lang.String" value="Sign For:"/>
+              </Properties>
+            </Component>
+            <Component class="javax.swing.JCheckBox" name="signForAllCheckbox">
+              <Properties>
+                <Property name="font" type="java.awt.Font" editor="org.netbeans.modules.form.editors2.FontEditor">
+                  <FontInfo relative="true">
+                    <Font component="signForAllCheckbox" property="font" relativeSize="true" size="0"/>
+                  </FontInfo>
+                </Property>
+                <Property name="selected" type="boolean" value="true"/>
+                <Property name="text" type="java.lang.String" value="All"/>
+                <Property name="toolTipText" type="java.lang.String" value="Enable/Disable signing for all requests."/>
+                <Property name="horizontalAlignment" type="int" value="11"/>
+              </Properties>
+              <AuxValues>
+                <AuxValue name="JavaCodeGenerator_VariableModifier" type="java.lang.Integer" value="1"/>
+              </AuxValues>
+            </Component>
+            <Component class="javax.swing.JCheckBox" name="signForRepeaterCheckbox">
+              <Properties>
+                <Property name="font" type="java.awt.Font" editor="org.netbeans.modules.form.editors2.FontEditor">
+                  <FontInfo relative="true">
+                    <Font component="signForRepeaterCheckbox" property="font" relativeSize="true" size="0"/>
+                  </FontInfo>
+                </Property>
+                <Property name="text" type="java.lang.String" value="Repeater"/>
+                <Property name="toolTipText" type="java.lang.String" value="Enable/Disable signing for Repeater requests."/>
+                <Property name="horizontalAlignment" type="int" value="11"/>
+              </Properties>
+              <AuxValues>
+                <AuxValue name="JavaCodeGenerator_VariableModifier" type="java.lang.Integer" value="1"/>
+              </AuxValues>
+            </Component>
+            <Component class="javax.swing.JCheckBox" name="signForProxyCheckbox">
+              <Properties>
+                <Property name="font" type="java.awt.Font" editor="org.netbeans.modules.form.editors2.FontEditor">
+                  <FontInfo relative="true">
+                    <Font component="signForProxyCheckbox" property="font" relativeSize="true" size="0"/>
+                  </FontInfo>
+                </Property>
+                <Property name="text" type="java.lang.String" value="Proxy"/>
+                <Property name="toolTipText" type="java.lang.String" value="Enable/Disable signing for Proxy requests."/>
+                <Property name="horizontalAlignment" type="int" value="11"/>
+              </Properties>
+              <AuxValues>
+                <AuxValue name="JavaCodeGenerator_VariableModifier" type="java.lang.Integer" value="1"/>
+              </AuxValues>
+            </Component>
+            <Component class="javax.swing.JCheckBox" name="signForIntruderCheckbox">
+              <Properties>
+                <Property name="font" type="java.awt.Font" editor="org.netbeans.modules.form.editors2.FontEditor">
+                  <FontInfo relative="true">
+                    <Font component="signForIntruderCheckbox" property="font" relativeSize="true" size="0"/>
+                  </FontInfo>
+                </Property>
+                <Property name="text" type="java.lang.String" value="Intruder "/>
+                <Property name="toolTipText" type="java.lang.String" value="Enable/Disable signing for Intruder requests."/>
+                <Property name="horizontalAlignment" type="int" value="11"/>
+              </Properties>
+              <AuxValues>
+                <AuxValue name="JavaCodeGenerator_VariableModifier" type="java.lang.Integer" value="1"/>
+              </AuxValues>
+            </Component>
+            <Component class="javax.swing.JCheckBox" name="signForExtensionsCheckbox">
+              <Properties>
+                <Property name="font" type="java.awt.Font" editor="org.netbeans.modules.form.editors2.FontEditor">
+                  <FontInfo relative="true">
+                    <Font component="signForExtensionsCheckbox" property="font" relativeSize="true" size="0"/>
+                  </FontInfo>
+                </Property>
+                <Property name="text" type="java.lang.String" value="Extensions"/>
+                <Property name="toolTipText" type="java.lang.String" value="Enable/Disable signing for Extension requests."/>
+                <Property name="horizontalAlignment" type="int" value="11"/>
+              </Properties>
+              <AuxValues>
+                <AuxValue name="JavaCodeGenerator_VariableModifier" type="java.lang.Integer" value="1"/>
+              </AuxValues>
+            </Component>
+            <Component class="javax.swing.JCheckBox" name="signForScannerCheckbox">
+              <Properties>
+                <Property name="font" type="java.awt.Font" editor="org.netbeans.modules.form.editors2.FontEditor">
+                  <FontInfo relative="true">
+                    <Font component="signForScannerCheckbox" property="font" relativeSize="true" size="0"/>
+                  </FontInfo>
+                </Property>
+                <Property name="text" type="java.lang.String" value="Scanner"/>
+                <Property name="toolTipText" type="java.lang.String" value="Enable/Disable signing for Scanner requests."/>
+                <Property name="horizontalAlignment" type="int" value="11"/>
+              </Properties>
+              <AuxValues>
+                <AuxValue name="JavaCodeGenerator_VariableModifier" type="java.lang.Integer" value="1"/>
+              </AuxValues>
+            </Component>
+            <Component class="javax.swing.JCheckBox" name="signForTargetCheckbox">
+              <Properties>
+                <Property name="font" type="java.awt.Font" editor="org.netbeans.modules.form.editors2.FontEditor">
+                  <FontInfo relative="true">
+                    <Font component="signForTargetCheckbox" property="font" relativeSize="true" size="0"/>
+                  </FontInfo>
+                </Property>
+                <Property name="text" type="java.lang.String" value="Target"/>
+                <Property name="toolTipText" type="java.lang.String" value="Enable/Disable signing for Target requests."/>
+                <Property name="horizontalAlignment" type="int" value="11"/>
+              </Properties>
+              <AuxValues>
+                <AuxValue name="JavaCodeGenerator_VariableModifier" type="java.lang.Integer" value="1"/>
+              </AuxValues>
+            </Component>
+            <Component class="javax.swing.JCheckBox" name="signForSequencerCheckbox">
+              <Properties>
+                <Property name="font" type="java.awt.Font" editor="org.netbeans.modules.form.editors2.FontEditor">
+                  <FontInfo relative="true">
+                    <Font component="signForSequencerCheckbox" property="font" relativeSize="true" size="0"/>
+                  </FontInfo>
+                </Property>
+                <Property name="text" type="java.lang.String" value="Sequencer"/>
+                <Property name="toolTipText" type="java.lang.String" value="Enable/Disable signing for Sequencer requests."/>
+                <Property name="horizontalAlignment" type="int" value="11"/>
+              </Properties>
+              <AuxValues>
+                <AuxValue name="JavaCodeGenerator_VariableModifier" type="java.lang.Integer" value="1"/>
+              </AuxValues>
+            </Component>
+          </SubComponents>
+        </Container>
+        <Component class="javax.swing.JCheckBox" name="persistConfigurationCheckbox">
+          <Properties>
+            <Property name="font" type="java.awt.Font" editor="org.netbeans.modules.form.editors2.FontEditor">
+              <FontInfo relative="true">
+                <Font component="persistConfigurationCheckbox" property="font" relativeSize="true" size="0"/>
+              </FontInfo>
+            </Property>
+            <Property name="selected" type="boolean" value="true"/>
+            <Property name="text" type="java.lang.String" value="Persist Configuration"/>
+            <Property name="toolTipText" type="java.lang.String" value="Enable/Disable configuration persistence."/>
+            <Property name="horizontalTextPosition" type="int" value="10"/>
+          </Properties>
+          <AuxValues>
+            <AuxValue name="JavaCodeGenerator_VariableModifier" type="java.lang.Integer" value="1"/>
+          </AuxValues>
         </Component>
       </SubComponents>
     </Container>
@@ -1116,9 +1333,9 @@
                                       <EmptySpace max="-2" attributes="0"/>
                                       <Component id="assumeRoleSessionPolicyConfigurationLabel" min="-2" pref="30" max="-2" attributes="0"/>
                                       <EmptySpace max="-2" attributes="0"/>
-                                      <Component id="assumeRoleSessionPolicyDescriptionLabel" pref="47" max="32767" attributes="0"/>
+                                      <Component id="assumeRoleSessionPolicyDescriptionLabel" pref="56" max="32767" attributes="0"/>
                                       <EmptySpace max="-2" attributes="0"/>
-                                      <Component id="assumeRoleSessionPolicyScrollPane" pref="357" max="32767" attributes="0"/>
+                                      <Component id="assumeRoleSessionPolicyScrollPane" pref="360" max="32767" attributes="0"/>
                                       <EmptySpace max="-2" attributes="0"/>
                                       <Component id="assumeRoleSessionPolicyPrettifyButton" min="-2" max="-2" attributes="0"/>
                                   </Group>
@@ -1214,7 +1431,7 @@
                                           <Group type="103" groupAlignment="0" attributes="0">
                                               <Component id="commandExtractedSectionLabel" alignment="0" min="-2" max="-2" attributes="0"/>
                                               <Group type="103" alignment="0" groupAlignment="1" max="-2" attributes="0">
-                                                  <Component id="commandConfigurationDescriptionLabel" alignment="0" pref="684" max="32767" attributes="0"/>
+                                                  <Component id="commandConfigurationDescriptionLabel" alignment="0" pref="692" max="32767" attributes="0"/>
                                                   <Group type="102" alignment="0" attributes="0">
                                                       <Group type="103" groupAlignment="0" attributes="0">
                                                           <Component id="commandDurationLabel" alignment="0" min="-2" max="-2" attributes="0"/>
@@ -1230,7 +1447,7 @@
                                               <Group type="102" alignment="0" attributes="0">
                                                   <EmptySpace min="10" pref="10" max="-2" attributes="0"/>
                                                   <Group type="103" groupAlignment="0" max="-2" attributes="0">
-                                                      <Component id="commandExtractedSectionDescriptionLabel" pref="672" max="32767" attributes="0"/>
+                                                      <Component id="commandExtractedSectionDescriptionLabel" pref="683" max="32767" attributes="0"/>
                                                       <Group type="102" attributes="0">
                                                           <Group type="103" groupAlignment="0" attributes="0">
                                                               <Component id="commandExtractedSessionTokenLabel" alignment="0" min="-2" max="-2" attributes="0"/>
@@ -1259,7 +1476,7 @@
                                   <EmptySpace max="-2" attributes="0"/>
                                   <Component id="commandConfigurationLabel" min="-2" pref="30" max="-2" attributes="0"/>
                                   <EmptySpace max="-2" attributes="0"/>
-                                  <Component id="commandConfigurationDescriptionLabel" pref="71" max="32767" attributes="0"/>
+                                  <Component id="commandConfigurationDescriptionLabel" pref="85" max="32767" attributes="0"/>
                                   <EmptySpace max="-2" attributes="0"/>
                                   <Group type="103" groupAlignment="3" attributes="0">
                                       <Component id="commandCommandLabel" alignment="3" min="-2" max="-2" attributes="0"/>

--- a/src/main/java/com/netspi/awssigner/view/BurpTabPanel.java
+++ b/src/main/java/com/netspi/awssigner/view/BurpTabPanel.java
@@ -1,8 +1,7 @@
 package com.netspi.awssigner.view;
 
 import com.netspi.awssigner.log.LogWriter;
-import java.awt.event.MouseAdapter;
-import java.awt.event.MouseEvent;
+
 import java.util.regex.Pattern;
 import javax.swing.border.EtchedBorder;
 
@@ -38,6 +37,17 @@ public class BurpTabPanel extends javax.swing.JPanel {
         logLevelLabel = new javax.swing.JLabel();
         logLevelComboBox = new javax.swing.JComboBox<>();
         globalSettingsSeparator = new javax.swing.JSeparator();
+        signForPanel = new javax.swing.JPanel();
+        signForLabel = new javax.swing.JLabel();
+        signForAllCheckbox = new javax.swing.JCheckBox();
+        signForRepeaterCheckbox = new javax.swing.JCheckBox();
+        signForProxyCheckbox = new javax.swing.JCheckBox();
+        signForIntruderCheckbox = new javax.swing.JCheckBox();
+        signForExtensionsCheckbox = new javax.swing.JCheckBox();
+        signForScannerCheckbox = new javax.swing.JCheckBox();
+        signForTargetCheckbox = new javax.swing.JCheckBox();
+        signForSequencerCheckbox = new javax.swing.JCheckBox();
+        persistConfigurationCheckbox = new javax.swing.JCheckBox();
         profileManagementLabel = new javax.swing.JLabel();
         profileManagementDescriptionLabel = new javax.swing.JLabel();
         addProfileButton = new javax.swing.JButton();
@@ -124,7 +134,7 @@ public class BurpTabPanel extends javax.swing.JPanel {
         signingEnabledCheckbox.setFont(signingEnabledCheckbox.getFont());
         signingEnabledCheckbox.setSelected(true);
         signingEnabledCheckbox.setText("Signing Enabled");
-        signingEnabledCheckbox.setToolTipText("Enable/Disable request signing globally");
+        signingEnabledCheckbox.setToolTipText("Enable/Disable request signing globally.");
         signingEnabledCheckbox.setHorizontalTextPosition(javax.swing.SwingConstants.LEADING);
 
         alwaysSignWithProfileLabel.setFont(alwaysSignWithProfileLabel.getFont());
@@ -144,46 +154,150 @@ public class BurpTabPanel extends javax.swing.JPanel {
         logLevelComboBox.setModel(new javax.swing.DefaultComboBoxModel<>(new String[] { "Error", "Info", "Debug" }));
         logLevelComboBox.setToolTipText("Set the extension's logging verbosity");
 
+        signForLabel.setText("Sign For:");
+
+        signForAllCheckbox.setFont(signForAllCheckbox.getFont());
+        signForAllCheckbox.setSelected(true);
+        signForAllCheckbox.setText("All");
+        signForAllCheckbox.setToolTipText("Enable/Disable signing for all requests.");
+        signForAllCheckbox.setHorizontalAlignment(javax.swing.SwingConstants.TRAILING);
+
+        signForRepeaterCheckbox.setFont(signForRepeaterCheckbox.getFont());
+        signForRepeaterCheckbox.setText("Repeater");
+        signForRepeaterCheckbox.setToolTipText("Enable/Disable signing for Repeater requests.");
+        signForRepeaterCheckbox.setHorizontalAlignment(javax.swing.SwingConstants.TRAILING);
+
+        signForProxyCheckbox.setFont(signForProxyCheckbox.getFont());
+        signForProxyCheckbox.setText("Proxy");
+        signForProxyCheckbox.setToolTipText("Enable/Disable signing for Proxy requests.");
+        signForProxyCheckbox.setHorizontalAlignment(javax.swing.SwingConstants.TRAILING);
+
+        signForIntruderCheckbox.setFont(signForIntruderCheckbox.getFont());
+        signForIntruderCheckbox.setText("Intruder ");
+        signForIntruderCheckbox.setToolTipText("Enable/Disable signing for Intruder requests.");
+        signForIntruderCheckbox.setHorizontalAlignment(javax.swing.SwingConstants.TRAILING);
+
+        signForExtensionsCheckbox.setFont(signForExtensionsCheckbox.getFont());
+        signForExtensionsCheckbox.setText("Extensions");
+        signForExtensionsCheckbox.setToolTipText("Enable/Disable signing for Extension requests.");
+        signForExtensionsCheckbox.setHorizontalAlignment(javax.swing.SwingConstants.TRAILING);
+
+        signForScannerCheckbox.setFont(signForScannerCheckbox.getFont());
+        signForScannerCheckbox.setText("Scanner");
+        signForScannerCheckbox.setToolTipText("Enable/Disable signing for Scanner requests.");
+        signForScannerCheckbox.setHorizontalAlignment(javax.swing.SwingConstants.TRAILING);
+
+        signForTargetCheckbox.setFont(signForTargetCheckbox.getFont());
+        signForTargetCheckbox.setText("Target");
+        signForTargetCheckbox.setToolTipText("Enable/Disable signing for Target requests.");
+        signForTargetCheckbox.setHorizontalAlignment(javax.swing.SwingConstants.TRAILING);
+
+        signForSequencerCheckbox.setFont(signForSequencerCheckbox.getFont());
+        signForSequencerCheckbox.setText("Sequencer");
+        signForSequencerCheckbox.setToolTipText("Enable/Disable signing for Sequencer requests.");
+        signForSequencerCheckbox.setHorizontalAlignment(javax.swing.SwingConstants.TRAILING);
+
+        javax.swing.GroupLayout signForPanelLayout = new javax.swing.GroupLayout(signForPanel);
+        signForPanel.setLayout(signForPanelLayout);
+        signForPanelLayout.setHorizontalGroup(
+            signForPanelLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
+            .addGroup(signForPanelLayout.createSequentialGroup()
+                .addContainerGap()
+                .addGroup(signForPanelLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
+                    .addComponent(signForLabel)
+                    .addGroup(signForPanelLayout.createSequentialGroup()
+                        .addGroup(signForPanelLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
+                            .addComponent(signForAllCheckbox)
+                            .addComponent(signForProxyCheckbox))
+                        .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                        .addGroup(signForPanelLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
+                            .addGroup(signForPanelLayout.createSequentialGroup()
+                                .addComponent(signForRepeaterCheckbox)
+                                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                                .addComponent(signForExtensionsCheckbox))
+                            .addGroup(signForPanelLayout.createSequentialGroup()
+                                .addComponent(signForIntruderCheckbox)
+                                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.UNRELATED)
+                                .addComponent(signForTargetCheckbox)))
+                        .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                        .addGroup(signForPanelLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
+                            .addComponent(signForSequencerCheckbox)
+                            .addComponent(signForScannerCheckbox))))
+                .addContainerGap(28, Short.MAX_VALUE))
+        );
+        signForPanelLayout.setVerticalGroup(
+            signForPanelLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
+            .addGroup(signForPanelLayout.createSequentialGroup()
+                .addContainerGap(javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
+                .addComponent(signForLabel)
+                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                .addGroup(signForPanelLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
+                    .addComponent(signForAllCheckbox)
+                    .addComponent(signForRepeaterCheckbox)
+                    .addComponent(signForExtensionsCheckbox)
+                    .addComponent(signForScannerCheckbox))
+                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                .addGroup(signForPanelLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
+                    .addComponent(signForProxyCheckbox)
+                    .addComponent(signForIntruderCheckbox)
+                    .addComponent(signForTargetCheckbox)
+                    .addComponent(signForSequencerCheckbox)))
+        );
+
+        persistConfigurationCheckbox.setFont(persistConfigurationCheckbox.getFont());
+        persistConfigurationCheckbox.setSelected(true);
+        persistConfigurationCheckbox.setText("Persist Configuration");
+        persistConfigurationCheckbox.setToolTipText("Enable/Disable configuration persistence.");
+        persistConfigurationCheckbox.setHorizontalTextPosition(javax.swing.SwingConstants.LEADING);
+
         javax.swing.GroupLayout globalSettingsPanelLayout = new javax.swing.GroupLayout(globalSettingsPanel);
         globalSettingsPanel.setLayout(globalSettingsPanelLayout);
         globalSettingsPanelLayout.setHorizontalGroup(
             globalSettingsPanelLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
+            .addComponent(globalSettingsSeparator)
             .addGroup(globalSettingsPanelLayout.createSequentialGroup()
                 .addContainerGap()
                 .addGroup(globalSettingsPanelLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-                    .addComponent(globalSettingsLabel)
                     .addGroup(globalSettingsPanelLayout.createSequentialGroup()
                         .addGap(10, 10, 10)
                         .addGroup(globalSettingsPanelLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
                             .addComponent(globalSettingsDescriptionLabel, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
                             .addGroup(globalSettingsPanelLayout.createSequentialGroup()
+                                .addComponent(persistConfigurationCheckbox)
+                                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
                                 .addComponent(signingEnabledCheckbox)
                                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.UNRELATED)
                                 .addComponent(alwaysSignWithProfileLabel)
                                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
                                 .addComponent(alwaysSignWithProfileComboBox, javax.swing.GroupLayout.PREFERRED_SIZE, 349, javax.swing.GroupLayout.PREFERRED_SIZE)
-                                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.UNRELATED)
+                                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
                                 .addComponent(logLevelLabel)
                                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                                .addComponent(logLevelComboBox, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)))))
-                .addGap(248, 391, Short.MAX_VALUE))
-            .addComponent(globalSettingsSeparator)
+                                .addComponent(logLevelComboBox, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))))
+                    .addComponent(globalSettingsLabel))
+                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                .addComponent(signForPanel, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
+                .addContainerGap(155, Short.MAX_VALUE))
         );
         globalSettingsPanelLayout.setVerticalGroup(
             globalSettingsPanelLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
             .addGroup(globalSettingsPanelLayout.createSequentialGroup()
-                .addContainerGap(javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
-                .addComponent(globalSettingsLabel)
-                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                .addComponent(globalSettingsDescriptionLabel, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
-                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.UNRELATED)
-                .addGroup(globalSettingsPanelLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
-                    .addComponent(signingEnabledCheckbox)
-                    .addComponent(alwaysSignWithProfileLabel)
-                    .addComponent(alwaysSignWithProfileComboBox, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
-                    .addComponent(logLevelLabel)
-                    .addComponent(logLevelComboBox, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
-                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                .addGroup(globalSettingsPanelLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
+                    .addGroup(globalSettingsPanelLayout.createSequentialGroup()
+                        .addContainerGap(javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
+                        .addComponent(globalSettingsLabel)
+                        .addGap(12, 12, 12)
+                        .addComponent(globalSettingsDescriptionLabel, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
+                        .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.UNRELATED)
+                        .addGroup(globalSettingsPanelLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
+                            .addComponent(signingEnabledCheckbox)
+                            .addComponent(alwaysSignWithProfileLabel)
+                            .addComponent(alwaysSignWithProfileComboBox, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
+                            .addComponent(logLevelLabel)
+                            .addComponent(logLevelComboBox, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
+                            .addComponent(persistConfigurationCheckbox)))
+                    .addComponent(signForPanel, javax.swing.GroupLayout.Alignment.TRAILING, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
+                .addGap(103, 103, 103)
                 .addComponent(globalSettingsSeparator, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
                 .addGap(8, 8, 8))
         );
@@ -435,9 +549,9 @@ public class BurpTabPanel extends javax.swing.JPanel {
                 .addContainerGap()
                 .addComponent(assumeRoleSessionPolicyConfigurationLabel, javax.swing.GroupLayout.PREFERRED_SIZE, 30, javax.swing.GroupLayout.PREFERRED_SIZE)
                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                .addComponent(assumeRoleSessionPolicyDescriptionLabel, javax.swing.GroupLayout.DEFAULT_SIZE, 47, Short.MAX_VALUE)
+                .addComponent(assumeRoleSessionPolicyDescriptionLabel, javax.swing.GroupLayout.DEFAULT_SIZE, 56, Short.MAX_VALUE)
                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                .addComponent(assumeRoleSessionPolicyScrollPane, javax.swing.GroupLayout.DEFAULT_SIZE, 357, Short.MAX_VALUE)
+                .addComponent(assumeRoleSessionPolicyScrollPane, javax.swing.GroupLayout.DEFAULT_SIZE, 360, Short.MAX_VALUE)
                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
                 .addComponent(assumeRoleSessionPolicyPrettifyButton))
         );
@@ -573,7 +687,7 @@ public class BurpTabPanel extends javax.swing.JPanel {
                         .addGroup(commandPanelLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
                             .addComponent(commandExtractedSectionLabel)
                             .addGroup(commandPanelLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.TRAILING, false)
-                                .addComponent(commandConfigurationDescriptionLabel, javax.swing.GroupLayout.Alignment.LEADING, javax.swing.GroupLayout.DEFAULT_SIZE, 684, Short.MAX_VALUE)
+                                .addComponent(commandConfigurationDescriptionLabel, javax.swing.GroupLayout.Alignment.LEADING, javax.swing.GroupLayout.DEFAULT_SIZE, 692, Short.MAX_VALUE)
                                 .addGroup(javax.swing.GroupLayout.Alignment.LEADING, commandPanelLayout.createSequentialGroup()
                                     .addGroup(commandPanelLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
                                         .addComponent(commandDurationLabel)
@@ -585,7 +699,7 @@ public class BurpTabPanel extends javax.swing.JPanel {
                             .addGroup(commandPanelLayout.createSequentialGroup()
                                 .addGap(10, 10, 10)
                                 .addGroup(commandPanelLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING, false)
-                                    .addComponent(commandExtractedSectionDescriptionLabel, javax.swing.GroupLayout.DEFAULT_SIZE, 672, Short.MAX_VALUE)
+                                    .addComponent(commandExtractedSectionDescriptionLabel, javax.swing.GroupLayout.DEFAULT_SIZE, 683, Short.MAX_VALUE)
                                     .addGroup(commandPanelLayout.createSequentialGroup()
                                         .addGroup(commandPanelLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
                                             .addComponent(commandExtractedSessionTokenLabel)
@@ -604,7 +718,7 @@ public class BurpTabPanel extends javax.swing.JPanel {
                 .addContainerGap()
                 .addComponent(commandConfigurationLabel, javax.swing.GroupLayout.PREFERRED_SIZE, 30, javax.swing.GroupLayout.PREFERRED_SIZE)
                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                .addComponent(commandConfigurationDescriptionLabel, javax.swing.GroupLayout.DEFAULT_SIZE, 71, Short.MAX_VALUE)
+                .addComponent(commandConfigurationDescriptionLabel, javax.swing.GroupLayout.DEFAULT_SIZE, 85, Short.MAX_VALUE)
                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
                 .addGroup(commandPanelLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
                     .addComponent(commandCommandLabel)
@@ -827,6 +941,7 @@ public class BurpTabPanel extends javax.swing.JPanel {
     public javax.swing.JButton importProfilesButton;
     public javax.swing.JComboBox<String> logLevelComboBox;
     private javax.swing.JLabel logLevelLabel;
+    public javax.swing.JCheckBox persistConfigurationCheckbox;
     private javax.swing.JLabel profileConfigurationLabel;
     public javax.swing.JPanel profileConfigurationPanel;
     public javax.swing.JScrollPane profileConfigurationScrollPane;
@@ -846,6 +961,16 @@ public class BurpTabPanel extends javax.swing.JPanel {
     private javax.swing.JLabel profileStatusLabel;
     public javax.swing.JLabel profileStatusTextLabel;
     public javax.swing.JPanel rightSideParentPanel;
+    public javax.swing.JCheckBox signForAllCheckbox;
+    public javax.swing.JCheckBox signForExtensionsCheckbox;
+    public javax.swing.JCheckBox signForIntruderCheckbox;
+    private javax.swing.JLabel signForLabel;
+    private javax.swing.JPanel signForPanel;
+    public javax.swing.JCheckBox signForProxyCheckbox;
+    public javax.swing.JCheckBox signForRepeaterCheckbox;
+    public javax.swing.JCheckBox signForScannerCheckbox;
+    public javax.swing.JCheckBox signForSequencerCheckbox;
+    public javax.swing.JCheckBox signForTargetCheckbox;
     public javax.swing.JCheckBox signingEnabledCheckbox;
     private javax.swing.JLabel staticAccessKeyLabel;
     public javax.swing.JTextField staticAccessKeyTextField;


### PR DESCRIPTION
This PR makes 2 major changes and 1 minor bugfix:

1. Adds support for configuring per-tool (i.e Repeater, Intruder, Proxy, etc.) signing. The most common usecase that inspired this functionality change is in situations where we would like to sign request made in Repeater with a profile, but not Sigv4 requests captured in the proxy. By default requests from all tools will be signed (if applicable).
2. Add support for saving settings/configurations on a per-project basis. This can be toggled in the UI, but is currently on by default. This closes #42.
3. (Bugfix) Handles an edge case where the Test Profile Credentials button would not always end up using the most up to date values in the associate profile's TextBox fields. This happens since immediately clicking the button while the textfield has focus doesn't trigger the current focus listener callback to fire, since technically the texfield doesnt lose focus when another button is clicked.